### PR TITLE
Add support for default_port in vectorized pad instances

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,9 +15,11 @@ Unreleased
 
 Added
 -----
+Added support for templated ``default_port`` in vectorized pad instances (pads with ``multiple`` > 1).
 
 Changed
 -------
+Removed now obsolete hint about ``default_port`` with vectorized pad instances compatibility.
 
 Fixed
 -----

--- a/docs/config_file.rst
+++ b/docs/config_file.rst
@@ -773,7 +773,6 @@ Here is an example:
     pad_type: pull_down_pad
     default_port: hs_gpio.gpio05
 
-.. hint:: At the moment, the `default_port` key **cannot** be combined with vectorized instantiation.
 ..
    Syntax Reference
    ================

--- a/src/padrick/Model/TemplatedPortIdentifier.py
+++ b/src/padrick/Model/TemplatedPortIdentifier.py
@@ -1,0 +1,38 @@
+from padrick.Model.TemplatedIdentifier import TemplatedIdentifierType
+
+
+class TemplatedPortIdentifierType(str):
+    def __init__(self, expression: str):
+        super().__init__()
+        if len(str(self).split(".")) != 2:
+            raise ValueError(f"Illegal templated port identifier '{str(self)}':\n"
+                             f"Must be of the form <templated_identifier>.<templated_identifier>")
+        port_group_str, port_str = str(self).split(".", maxsplit=1)
+
+        try:
+            self._port_group = TemplatedIdentifierType(port_group_str)
+            self._port = TemplatedIdentifierType(port_str)
+        except ValueError as e:
+            raise ValueError(f"Illegal templated port identifier '{str(self)}':\n{str(e)}")
+
+    @property
+    def identifier(self) -> str:
+        return str(self)
+
+    def evaluate_template(self, i):
+        return self._port_group.evaluate_template(i)+"."+self._port.evaluate_template(i)
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        try:
+            expr = cls(v)
+        except ValueError as e:
+            raise ValueError(f'Error while parsing expression: {v}.\nError {str(e)}')
+        return expr
+
+    def __repr__(self):
+        return self.__str__()


### PR DESCRIPTION
Until now, it was not possible to combine the `default_port ` key with the `multiple` key when specifying vectorized pad_instances in the `pad_list`. This PR changes that and adds proper support for templated default ports. The change is fully backward compatible, thus no manifest version bump is required.